### PR TITLE
Fix typos

### DIFF
--- a/data/org.mpdevil.mpdevil.appdata.xml
+++ b/data/org.mpdevil.mpdevil.appdata.xml
@@ -10,7 +10,7 @@
     <p>Mpdevil is a simple music browser for the Music Player Daemon (MPD) which is focused on playing local music without the need of managing playlists. Instead of maintaining a client side database of your music library mpdevil loads all tags and covers on demand. So you'll never see any outdated information in the browser. Mpdevil strongly relies on tags.</p>
     <ul>
       <li>Display large covers</li>
-      <li>Play songs without doubleclick</li>
+      <li>Play songs without double-click</li>
       <li>Fetch lyrics</li>
       <li>MPRIS interface</li>
       <li>Basic queue manipulation (move and delete single tracks)</li>

--- a/src/mpdevil.py
+++ b/src/mpdevil.py
@@ -1266,7 +1266,7 @@ class TreeView(Gtk.TreeView):
 		return (rect.x+rect.width//2, max(min(cell.y+cell.height//2, rect.y+rect.height), rect.y))
 
 	def save_set_cursor(self, *args, **kwargs):
-		# The standard set_cursor function should scroll normally, but it dosen't work as it should when the treeview is not completely
+		# The standard set_cursor function should scroll normally, but it doesn't work as it should when the treeview is not completely
 		# initialized. This usually happens when the program is freshly started and the treeview isn't done with its internal tasks.
 		# See: https://lazka.github.io/pgi-docs/GLib-2.0/constants.html#GLib.PRIORITY_HIGH_IDLE
 		# Running set_cursor with a lower priority ensures that the treeview is done before it gets scrolled.


### PR DESCRIPTION
Found via `codespell -S po`