### PR TITLE
Adding "Insert Next" in the SongsList context menu

### DIFF
--- a/src/mpdevil.py
+++ b/src/mpdevil.py
@@ -777,7 +777,17 @@ class Client(MPDClient):
 		self._to_playlist(append, mode)
 
 	def filter_to_playlist(self, tag_filter, mode):
-		def append():
+		def append(next=False):
+			if next:
+				status=self.status()
+				try:
+					if tag_filter:
+						self.findadd(*tag_filter) # should be self.find() then insert in reverse order
+					else:
+						self.searchadd("any", "") # should be self.search() then insert in reverse order
+					return
+				except KeyError: # status["song"] can fail on empty playlist. Drop through.
+					pass
 			if tag_filter:
 				self.findadd(*tag_filter)
 			else:

--- a/src/mpdevil.py
+++ b/src/mpdevil.py
@@ -765,7 +765,9 @@ class Client(MPDClient):
 			if next:
 				status=self.status()
 				try:
-					for f in files:
+					songs = [s for s in files]
+					songs.reverse()
+					for f in songs:
 						self.addid(f, int(status["song"])+1)
 					return
 				except KeyError: # status["song"] can fail on empty playlist. Drop through.

--- a/src/mpdevil.py
+++ b/src/mpdevil.py
@@ -1329,7 +1329,7 @@ class SongsList(TreeView):
 		menu.append(_("Append"), "menu.append")
 		menu.append(_("Play"), "menu.play")
 		menu.append(_("Show"), "menu.show")
-		menu.append(_("Insert Next"), "menu.insert_next")
+		menu.append(_("As Next"), "menu.insert_next")
 		self._menu=Gtk.Popover.new_from_model(self, menu)
 		self._menu.set_position(Gtk.PositionType.BOTTOM)
 

--- a/src/mpdevil.py
+++ b/src/mpdevil.py
@@ -764,14 +764,10 @@ class Client(MPDClient):
 		def append(next=False):
 			if next:
 				status=self.status()
-				try:
-					songs = [s for s in files]
-					songs.reverse()
-					for f in songs:
+				if status["state"] != "stop":
+					for f in reversed([s for s in files]):
 						self.addid(f, int(status["song"])+1)
 					return
-				except KeyError: # status["song"] can fail on empty playlist. Drop through.
-					pass
 			for f in files:
 				self.add(f)
 		self._to_playlist(append, mode)
@@ -780,14 +776,14 @@ class Client(MPDClient):
 		def append(next=False):
 			if next:
 				status=self.status()
-				try:
+				if status["state"] != "stop":
 					if tag_filter:
-						self.findadd(*tag_filter) # should be self.find() then insert in reverse order
+						files = self.find(*tag_filter)
 					else:
-						self.searchadd("any", "") # should be self.search() then insert in reverse order
+						files = self.search("any", "")
+					for f in reversed([s for s in files]):
+						self.addid(f, int(status["song"])+1)
 					return
-				except KeyError: # status["song"] can fail on empty playlist. Drop through.
-					pass
 			if tag_filter:
 				self.findadd(*tag_filter)
 			else:

--- a/src/mpdevil.py
+++ b/src/mpdevil.py
@@ -1302,6 +1302,7 @@ class SongsList(TreeView):
 		# buttons
 		self.buttons=Gtk.ButtonBox(layout_style=Gtk.ButtonBoxStyle.EXPAND)
 		data=((_("Append"), "list-add-symbolic", "append"),
+			(_("As Next"), "list-insert_next-symbolic", "insert_next"),
 			(_("Play"), "media-playback-start-symbolic", "play")
 		)
 		for tooltip, icon, mode in data:

--- a/src/mpdevil.py
+++ b/src/mpdevil.py
@@ -733,10 +733,10 @@ class Client(MPDClient):
 		except:
 			return False
 
-	def _to_playlist(self, append, mode):  # modes: play, append, enqueue
+	def _to_playlist(self, append, mode):  # modes: play, append, insert_next, enqueue
 		if mode == "append":
 			append()
-		if mode == "insert_next":
+		elif mode == "insert_next":
 			append(next=True)
 		elif mode == "play":
 			self.clear()


### PR DESCRIPTION
I found myself wanting this functionality: don't interrupt the current song (unlike "play"), just insert the item after the current playing item. So it differs slightly from "append" (adding to end of playlist) too.