### PR TITLE
Add 'Keywords' section to .desktop file

### DIFF
--- a/data/org.mpdevil.mpdevil.desktop.in
+++ b/data/org.mpdevil.mpdevil.desktop.in
@@ -8,3 +8,4 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Audio;AudioVideo;Player;GTK
+Keywords=Music;Player;


### PR DESCRIPTION
Silly little PR! However, a keywords section should make mpdevil easier to find from, say, GNOME's activities overview.

For example, GNOME music, spotify, [celluloid](https://github.com/celluloid-player/celluloid) and other media players all show up when I type "Music" in the activities overview. 

This is because of the presence of this line in their respective .desktop files:

```conf
Keywords=Music;Player;
```

This PR adds this line to  `mpdevil`'s desktop file to achieve the same behavior. 