### PR TITLE
Update readme python-mpd2 build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Dependencies:
 - Python3
 
 Python modules:
-- mpd (python-mpd2 >=1.1)
+- mpd (python-mpd2 >=3.1)
 - gi (Gtk, Adw, Gio, Gdk, Pango, GObject, GLib)
 
 Run:


### PR DESCRIPTION
Also, I just wanted to check you realise v3.1 isn't in Debian Bookworm and so the deb is currently incompatible with Debian and Pi OS etc (non-testing).